### PR TITLE
Use leftLabel and default styling in suggestions.

### DIFF
--- a/lib/omnisharp-atom/features/lib/completion-provider.ts
+++ b/lib/omnisharp-atom/features/lib/completion-provider.ts
@@ -121,11 +121,12 @@ export var CompletionProvider = {
         return {
             _search: item.CompletionText,
             snippet: item.Snippet,
-            type: item.Kind,
+            type: item.Kind.toLowercase(),
             iconHTML: this.renderIcon(item),
             displayText: escape(item.DisplayText),
             className: 'autocomplete-omnisharp-atom',
-            description: this.renderReturnType(item.ReturnType)
+            description: item.RequiredNamespaceImport,
+            leftLabel: item.ReturnType,
         }
     },
 
@@ -158,13 +159,6 @@ export var CompletionProvider = {
     },
 
     dispose() {
-    },
-
-    renderReturnType(returnType: string) {
-        if (returnType === null) {
-            return;
-        }
-        return `Returns: ${returnType}`;
     },
 
     renderIcon(item) {


### PR DESCRIPTION
It's uncommon for autocomplete providers to use the description box for return types, so I have instead used the leftLabel property to display the return type. This is a right-aligned column placed before the displayText that, by default, is slightly dimmed and is easier to read.

In addition, the description field is now used to show required namespace imports, and the type will use the default colorization in autocomplete for a few types. This could be expanded to correctly map each kind in C# to the default types in autocomplete, but for now it's able to colorize properties and methods similarly to other completion providers, in addition to the icons used in OmniSharp.

What it looks like (_I have personally disabled the icons for my own use, they are still enabled in this PR_):

![](http://i.imgur.com/w0eNsXO.png)

Naturally this doesn't quite match up with Visual Studio's presentation for IntelliSense completion suggestions, but I think it better conforms with what Atom users might expect when using completions. It is based more on what the [autocomplete-plus API shows in their wiki](https://github.com/atom/autocomplete-plus/wiki/Provider-API#suggestions).